### PR TITLE
feat: integrate frontend with backend APIs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,21 @@
+import { useEffect } from "react";
 import { RouterProvider } from "react-router-dom";
-import { router } from "./router";
 import { Theme } from "@radix-ui/themes";
+import { router } from "./router";
+import { useAuthStore } from "./stores/auth";
 
 function App() {
+  const { token, getProfile } = useAuthStore((state) => ({
+    token: state.token,
+    getProfile: state.getProfile,
+  }));
+
+  useEffect(() => {
+    if (token) {
+      getProfile();
+    }
+  }, [token, getProfile]);
+
   return (
     <Theme>
       <RouterProvider router={router} />

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,36 @@
+import { api } from "./client";
+import type { Role } from "../models/user";
+import type { User } from "../models/user";
+
+export interface LoginPayload {
+  email: string;
+  password: string;
+}
+
+export interface RegisterPayload {
+  name: string;
+  email: string;
+  password: string;
+  role: Role;
+  barberShopId?: string;
+}
+
+export interface AuthResponse {
+  token: string;
+  user: User;
+}
+
+export const login = async (payload: LoginPayload) => {
+  const { data } = await api.post<AuthResponse>("/auth/login", payload);
+  return data;
+};
+
+export const register = async (payload: RegisterPayload) => {
+  const { data } = await api.post<AuthResponse>("/auth/register", payload);
+  return data;
+};
+
+export const getProfile = async () => {
+  const { data } = await api.get<User>("/users/me");
+  return data;
+};

--- a/src/api/barbershops.ts
+++ b/src/api/barbershops.ts
@@ -1,0 +1,36 @@
+import { api } from "./client";
+import type { Barbershop } from "../models/barbershop";
+import type { Invite } from "../models/invite";
+
+export interface CreateBarbershopPayload {
+  name: string;
+  address: string;
+  latitude?: number;
+  longitude?: number;
+  phone?: string;
+}
+
+export interface CreateInvitePayload {
+  barbershopId: string;
+  expiresAt?: string;
+}
+
+export const listBarberShops = async () => {
+  const { data } = await api.get<Barbershop[]>("/barber-shops");
+  return data;
+};
+
+export const getBarberShop = async (barbershopId: string) => {
+  const { data } = await api.get<Barbershop>(`/barber-shop/${barbershopId}`);
+  return data;
+};
+
+export const createBarberShop = async (payload: CreateBarbershopPayload) => {
+  const { data } = await api.post<Barbershop>("/barber-shop", payload);
+  return data;
+};
+
+export const createBarberShopInvite = async (payload: CreateInvitePayload) => {
+  const { data } = await api.post<Invite>("/barber-shop/invite", payload);
+  return data;
+};

--- a/src/api/bookings.ts
+++ b/src/api/bookings.ts
@@ -1,0 +1,27 @@
+import { api } from "./client";
+import type { Booking, BookingStatus } from "../models/booking";
+
+export interface CreateBookingPayload {
+  serviceId: string;
+  date: string;
+  barberId?: string;
+}
+
+export interface UpdateBookingStatusPayload {
+  status: BookingStatus;
+}
+
+export const createBooking = async (payload: CreateBookingPayload) => {
+  const { data } = await api.post<Booking>("/bookings", payload);
+  return data;
+};
+
+export const listBookings = async () => {
+  const { data } = await api.get<Booking[]>("/bookings");
+  return data;
+};
+
+export const updateBookingStatus = async (bookingId: string, payload: UpdateBookingStatusPayload) => {
+  const { data } = await api.patch<Booking>(`/bookings/${bookingId}`, payload);
+  return data;
+};

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,11 +1,21 @@
 import axios from "axios";
 
+const baseURL = import.meta.env.VITE_API_URL ?? "http://localhost:3600/api";
+
 export const api = axios.create({
-  baseURL: "http://localhost:3600/api",
+  baseURL,
 });
 
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem("token");
-  if (token) config.headers.Authorization = `Bearer ${token}`;
+  if (token) {
+    config.headers = config.headers ?? {};
+
+    if (typeof config.headers.set === "function") {
+      config.headers.set("Authorization", `Bearer ${token}`);
+    } else {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+  }
   return config;
-}); 
+});

--- a/src/api/services.ts
+++ b/src/api/services.ts
@@ -1,0 +1,28 @@
+import { api } from "./client";
+import type { Service } from "../models/service";
+
+export interface ServicePayload {
+  barbershopId: string;
+  name: string;
+  price?: number;
+  duration?: number;
+}
+
+export const listServices = async () => {
+  const { data } = await api.get<Service[]>("/services");
+  return data;
+};
+
+export const createService = async (payload: ServicePayload) => {
+  const { data } = await api.post<Service>("/services", payload);
+  return data;
+};
+
+export const updateService = async (serviceId: string, payload: Partial<ServicePayload>) => {
+  const { data } = await api.put<Service>(`/services/${serviceId}`, payload);
+  return data;
+};
+
+export const deleteService = async (serviceId: string) => {
+  await api.delete(`/services/${serviceId}`);
+};

--- a/src/models/barbershop.ts
+++ b/src/models/barbershop.ts
@@ -5,12 +5,12 @@ export interface Barbershop {
   id: string;
   name: string;
   address: string;
-  latitude: number;
-  longitude: number;
-  phone: string;
-  ownerId: string;
-  invites: Invite[];
-  createdAt: Date;
-  updatedAt: Date;
-  services: Service[];
-};
+  latitude?: number | null;
+  longitude?: number | null;
+  phone?: string | null;
+  ownerId?: string | null;
+  invites?: Invite[];
+  createdAt?: string;
+  updatedAt?: string;
+  services?: Service[];
+}

--- a/src/models/booking.ts
+++ b/src/models/booking.ts
@@ -3,14 +3,14 @@ export interface Booking {
   clientId: string;
   barberId: string;
   barbershopId: string;
-  date: Date;
+  date: string;
   status: BookingStatus;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export enum BookingStatus {
-  PENDING,
-  CONFIRMED,
-  CANCELED,
+  PENDING = "PENDING",
+  CONFIRMED = "CONFIRMED",
+  CANCELED = "CANCELED",
 }

--- a/src/models/invite.ts
+++ b/src/models/invite.ts
@@ -1,8 +1,8 @@
 export interface Invite {
   id: string;
   code: string;
-  barbershopId: string,
-  expiresAt: string,
-  createdAt: string,
-  expired: boolean,
+  barbershopId: string;
+  expiresAt: string;
+  createdAt: string;
+  expired: boolean;
 }

--- a/src/models/service.ts
+++ b/src/models/service.ts
@@ -6,7 +6,7 @@ export interface Service {
   name: string;
   price?: number;
   duration?: number;
-  createdAt?: Date;
-  updatedAt?: Date;
+  createdAt?: string;
+  updatedAt?: string;
   bookings?: Booking[];
 }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -4,17 +4,16 @@ export interface User {
   id: string;
   name: string;
   email: string;
-  password: string;
   role: Role;
-  barberShopId: string;
-  createdAt: Date;
-  updatedAt: Date;
-  booking: Booking[]
-};
+  barberShopId?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+  booking?: Booking[];
+}
 
 export enum Role {
   CLIENT = 'CLIENT',
   BARBER = 'BARBER',
   OWNER = 'OWNER',
-};
+}
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,48 +1,109 @@
 import { Dialog, Select } from "radix-ui";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import type { Barbershop } from "../models/barbershop";
-import { mockBarbershops } from "../utils/mock";
-import { Clock, Filter, MapPin, Navigation, Phone, Search, Star } from "lucide-react";
+import { Clock, Filter, MapPin, Navigation, Phone, Search, Star, Users } from "lucide-react";
+import { useBarbershopStore } from "../stores/barbershop";
+
+const registrationOptions = [
+  {
+    label: "Sou Cliente",
+    description: "Quero agendar horários em barbearias",
+    role: "CLIENT",
+  },
+  {
+    label: "Sou Barbeiro",
+    description: "Quero gerenciar minha agenda de atendimentos",
+    role: "BARBER",
+  },
+  {
+    label: "Sou Dono de Barbearia",
+    description: "Quero cadastrar minha barbearia e a equipe",
+    role: "OWNER",
+  },
+] as const;
+
+type SortOption = "distance" | "rating" | "name";
 
 const Home = () => {
-  const [searchTerm, setSearchTerm] = useState('');
+  const [searchTerm, setSearchTerm] = useState("");
   const [selectedBarbershop, setSelectedBarbershop] = useState<Barbershop | null>(null);
-  const [sortBy, setSortBy] = useState('distance');
+  const [sortBy, setSortBy] = useState<SortOption>("distance");
+  const [isRegisterDialogOpen, setIsRegisterDialogOpen] = useState(false);
 
-  const filteredBarbershops = mockBarbershops
-    .filter(shop =>
-      shop.name.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      shop.address.toLowerCase().includes(searchTerm.toLowerCase())
-    )
-    .sort((a, b) => {
-      if (sortBy === 'distance') return 0;
-      if (sortBy === 'rating') return 0;
-      if (sortBy === 'name') return a.name.localeCompare(b.name);
+  const { barbershops, fetchBarbershops, isLoading, error } = useBarbershopStore((state) => ({
+    barbershops: state.barbershops,
+    fetchBarbershops: state.fetchBarbershops,
+    isLoading: state.isLoading,
+    error: state.error,
+  }));
+
+  useEffect(() => {
+    fetchBarbershops();
+  }, [fetchBarbershops]);
+
+  const filteredBarbershops = useMemo(() => {
+    const normalizedTerm = searchTerm.trim().toLowerCase();
+
+    const filtered = normalizedTerm
+      ? barbershops.filter((shop) => {
+          const name = shop.name?.toLowerCase() ?? "";
+          const address = shop.address?.toLowerCase() ?? "";
+          return name.includes(normalizedTerm) || address.includes(normalizedTerm);
+        })
+      : barbershops;
+
+    return filtered.slice().sort((a, b) => {
+      if (sortBy === "name") {
+        return (a.name ?? "").localeCompare(b.name ?? "");
+      }
+
+      if (sortBy === "rating") {
+        const ratingA = (a as unknown as { rating?: number }).rating ?? 0;
+        const ratingB = (b as unknown as { rating?: number }).rating ?? 0;
+        return ratingB - ratingA;
+      }
+
       return 0;
     });
+  }, [barbershops, searchTerm, sortBy]);
 
   const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('pt-BR', {
-      style: 'currency',
-      currency: 'BRL'
+    return new Intl.NumberFormat("pt-BR", {
+      style: "currency",
+      currency: "BRL",
     }).format(price);
   };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100">
-      
       {/* Header */}
       <header className="bg-white shadow-sm border-b border-gray-200">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
             <div>
               <h1 className="text-3xl font-bold text-gray-900">FindCut</h1>
-              <p className="text-gray-600 mt-1">Encontre as melhores barbearias perto de você</p>
+              <p className="text-gray-600 mt-1">
+                Encontre as melhores barbearias perto de você ou gerencie o seu negócio.
+              </p>
             </div>
-            <div className="flex items-center gap-2 text-sm text-gray-500">
-              <Navigation className="w-4 h-4" />
-              <span>Campinas, SP</span>
-            </div>
+
+            <nav className="flex items-center gap-3 self-start lg:self-auto">
+              <Link
+                to="/login"
+                className="text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors"
+              >
+                Entrar
+              </Link>
+              <button
+                type="button"
+                onClick={() => setIsRegisterDialogOpen(true)}
+                className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+              >
+                <Users className="h-4 w-4" />
+                Quero me cadastrar
+              </button>
+            </nav>
           </div>
 
           {/* Search and Filters */}
@@ -58,10 +119,10 @@ const Home = () => {
               />
             </div>
 
-            <Select.Root value={sortBy} onValueChange={setSortBy}>
+            <Select.Root value={sortBy} onValueChange={(value) => setSortBy(value as SortOption)}>
               <Select.Trigger className="flex items-center gap-2 px-4 py-3 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 focus:ring-2 focus:ring-blue-500">
                 <Filter className="w-4 h-4" />
-                <Select.Value />
+                <Select.Value placeholder="Ordenar por" />
                 <Select.Icon />
               </Select.Trigger>
               <Select.Portal>
@@ -84,91 +145,100 @@ const Home = () => {
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="mb-6">
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">
-            {filteredBarbershops.length} barbearias encontradas
-          </h2>
-          <p className="text-gray-600">Clique em uma barbearia para ver mais detalhes</p>
-        </div>
-
-        {/* Barbershop Grid */}
-        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-          {filteredBarbershops.map((barbershop) => (
-            <div
-              key={barbershop.id}
-              className="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden hover:shadow-lg transition-all duration-300 cursor-pointer"
-              onClick={() => setSelectedBarbershop(barbershop)}
-            >
-              <div className="relative">
-                <img
-                  src="https://images.unsplash.com/photo-1503951914875-452162b0f3f1?w=400&h=300&fit=crop"
-                  alt={barbershop.name}
-                  className="w-full h-48 object-cover"
-                />
-                <div className="absolute top-4 right-4 flex items-center gap-2">
-                  <span className="bg-green-100 text-green-800 text-xs font-medium px-2 py-1 rounded-full">
-                    Aberto
-                  </span>
-                </div>
-                <div className="absolute top-4 left-4">
-                  <div className="flex items-center gap-1 bg-black bg-opacity-70 text-white px-2 py-1 rounded">
-                    <Star className="w-3 h-3 fill-yellow-400 text-yellow-400" />
-                    <span className="text-xs font-medium">4.8</span>
-                  </div>
-                </div>
-              </div>
-
-              <div className="p-6">
-                <h3 className="text-lg font-semibold text-gray-900 mb-2">
-                  {barbershop.name}
-                </h3>
-
-                <div className="space-y-2 mb-4">
-                  <div className="flex items-center gap-2 text-gray-600">
-                    <MapPin className="w-4 h-4" />
-                    <span className="text-sm">{barbershop.address}</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-gray-600">
-                    <Navigation className="w-4 h-4" />
-                    <span className="text-sm">Próximo</span>
-                  </div>
-                  <div className="flex items-center gap-2 text-gray-600">
-                    <Phone className="w-4 h-4" />
-                    <span className="text-sm">{barbershop.phone}</span>
-                  </div>
-                </div>
-
-                <div className="border-t pt-4">
-                  <p className="text-sm text-gray-500 mb-2">Serviços populares:</p>
-                  <div className="flex flex-wrap gap-2">
-                    {barbershop.services.slice(0, 2).map((service) => (
-                      <span
-                        key={service.id}
-                        className="bg-blue-50 text-blue-700 text-xs px-2 py-1 rounded-full"
-                      >
-                        {service.name} - {formatPrice(service.price ?? 0)}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {/* Empty State */}
-        {filteredBarbershops.length === 0 && (
-          <div className="text-center py-12">
-            <div className="w-24 h-24 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center">
-              <Search className="w-8 h-8 text-gray-400" />
-            </div>
-            <h3 className="text-lg font-medium text-gray-900 mb-2">
-              Nenhuma barbearia encontrada
-            </h3>
-            <p className="text-gray-600">
-              Tente ajustar seus filtros ou termo de busca
-            </p>
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="animate-spin rounded-full h-12 w-12 border-4 border-blue-500 border-t-transparent" />
           </div>
+        ) : (
+          <>
+            <div className="mb-6">
+              <h2 className="text-xl font-semibold text-gray-900 mb-2">
+                {filteredBarbershops.length} barbearia(s) encontrada(s)
+              </h2>
+              <p className="text-gray-600">Clique em uma barbearia para ver mais detalhes.</p>
+            </div>
+
+            {error && (
+              <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                {error}
+              </div>
+            )}
+
+            {/* Barbershop Grid */}
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {filteredBarbershops.map((barbershop) => (
+                <button
+                  type="button"
+                  key={barbershop.id}
+                  className="text-left bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden hover:shadow-lg transition-all duration-300"
+                  onClick={() => setSelectedBarbershop(barbershop)}
+                >
+                  <div className="relative">
+                    <img
+                      src="https://images.unsplash.com/photo-1503951914875-452162b0f3f1?w=400&h=300&fit=crop"
+                      alt={barbershop.name}
+                      className="w-full h-48 object-cover"
+                    />
+                    <div className="absolute top-4 right-4 flex items-center gap-2">
+                      <span className="bg-green-100 text-green-800 text-xs font-medium px-2 py-1 rounded-full">
+                        Aberto
+                      </span>
+                    </div>
+                    <div className="absolute top-4 left-4">
+                      <div className="flex items-center gap-1 bg-black bg-opacity-70 text-white px-2 py-1 rounded">
+                        <Star className="w-3 h-3 fill-yellow-400 text-yellow-400" />
+                        <span className="text-xs font-medium">4.8</span>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="p-6 space-y-4">
+                    <div>
+                      <h3 className="text-lg font-semibold text-gray-900">
+                        {barbershop.name}
+                      </h3>
+                      <p className="mt-1 text-sm text-gray-600 line-clamp-2">
+                        {barbershop.address}
+                      </p>
+                    </div>
+
+                    <div className="flex items-center gap-2 text-sm text-gray-500">
+                      <Navigation className="w-4 h-4" />
+                      <span>Próximo de você</span>
+                    </div>
+
+                    <div className="border-t pt-4">
+                      <p className="text-sm text-gray-500 mb-2">Serviços populares:</p>
+                      <div className="flex flex-wrap gap-2">
+                        {(barbershop.services ?? []).slice(0, 2).map((service) => (
+                          <span
+                            key={service.id}
+                            className="bg-blue-50 text-blue-700 text-xs px-2 py-1 rounded-full"
+                          >
+                            {service.name} {service.price ? `- ${formatPrice(service.price)}` : ""}
+                          </span>
+                        ))}
+                        {(barbershop.services ?? []).length === 0 && (
+                          <span className="text-xs text-gray-400">Nenhum serviço cadastrado ainda.</span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+
+            {/* Empty State */}
+            {filteredBarbershops.length === 0 && !error && (
+              <div className="text-center py-12">
+                <div className="w-24 h-24 mx-auto mb-4 bg-gray-100 rounded-full flex items-center justify-center">
+                  <Search className="w-8 h-8 text-gray-400" />
+                </div>
+                <h3 className="text-lg font-medium text-gray-900 mb-2">Nenhuma barbearia encontrada</h3>
+                <p className="text-gray-600">Tente ajustar seus filtros ou termo de busca.</p>
+              </div>
+            )}
+          </>
         )}
       </main>
 
@@ -181,7 +251,7 @@ const Home = () => {
               <>
                 <div className="relative">
                   <img
-                    src="https://images.unsplash.com/photo-1503951914875-452162b0f3f1?w=400&h=300&fit=crop"
+                    src="https://images.unsplash.com/photo-1503951914875-452162b0f3f1?w=800&h=400&fit=crop"
                     alt={selectedBarbershop.name}
                     className="w-full h-64 object-cover rounded-t-xl"
                   />
@@ -217,35 +287,40 @@ const Home = () => {
                       <MapPin className="w-5 h-5 text-gray-400" />
                       <span>{selectedBarbershop.address}</span>
                     </div>
-                    <div className="flex items-center gap-3 text-gray-700">
-                      <Phone className="w-5 h-5 text-gray-400" />
-                      <span>{selectedBarbershop.phone}</span>
-                    </div>
+                    {selectedBarbershop.phone && (
+                      <div className="flex items-center gap-3 text-gray-700">
+                        <Phone className="w-5 h-5 text-gray-400" />
+                        <span>{selectedBarbershop.phone}</span>
+                      </div>
+                    )}
                   </div>
 
                   <div className="border-t pt-6">
                     <h3 className="text-lg font-semibold text-gray-900 mb-4">Serviços</h3>
                     <div className="space-y-3">
-                      {selectedBarbershop.services.map((service) => (
+                      {(selectedBarbershop.services ?? []).map((service) => (
                         <div key={service.id} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
                           <div>
                             <h4 className="font-medium text-gray-900">{service.name}</h4>
                             <div className="flex items-center gap-2 text-sm text-gray-600">
                               <Clock className="w-4 h-4" />
-                              <span>{service.duration} min</span>
+                              <span>{service.duration ? `${service.duration} min` : "Duração sob consulta"}</span>
                             </div>
                           </div>
                           <div className="text-lg font-semibold text-gray-900">
-                            {formatPrice(service.price ?? 0)}
+                            {service.price ? formatPrice(service.price) : "Sob consulta"}
                           </div>
                         </div>
                       ))}
+                      {(selectedBarbershop.services ?? []).length === 0 && (
+                        <p className="text-sm text-gray-500">Esta barbearia ainda não cadastrou serviços.</p>
+                      )}
                     </div>
                   </div>
 
                   <div className="mt-6 pt-6 border-t">
                     <button className="w-full bg-blue-600 hover:bg-blue-700 text-white font-medium py-3 px-4 rounded-lg transition-colors">
-                      Agendar Horário
+                      Agendar horário
                     </button>
                   </div>
                 </div>
@@ -254,8 +329,46 @@ const Home = () => {
           </Dialog.Content>
         </Dialog.Portal>
       </Dialog.Root>
+
+      {/* Register dialog */}
+      <Dialog.Root open={isRegisterDialogOpen} onOpenChange={setIsRegisterDialogOpen}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="bg-black bg-opacity-50 fixed inset-0 z-40" />
+          <Dialog.Content className="fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-white rounded-xl shadow-xl p-6 z-50 max-w-lg w-full mx-4">
+            <div className="mb-6">
+              <Dialog.Title className="text-2xl font-semibold text-gray-900">Como você quer usar o FindCut?</Dialog.Title>
+              <Dialog.Description className="text-gray-600 mt-2">
+                Escolha a opção que melhor representa o seu perfil para continuar o cadastro.
+              </Dialog.Description>
+            </div>
+
+            <div className="space-y-3">
+              {registrationOptions.map((option) => (
+                <Link
+                  key={option.role}
+                  to={`/register?role=${option.role}`}
+                  className="block rounded-lg border border-gray-200 p-4 hover:border-blue-500 hover:bg-blue-50 transition-all"
+                  onClick={() => setIsRegisterDialogOpen(false)}
+                >
+                  <div className="text-sm font-semibold text-gray-900">{option.label}</div>
+                  <p className="text-xs text-gray-600 mt-1">{option.description}</p>
+                </Link>
+              ))}
+            </div>
+
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                className="mt-6 w-full rounded-lg border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50"
+              >
+                Cancelar
+              </button>
+            </Dialog.Close>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </div>
   );
-}
+};
 
 export default Home;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,21 +1,101 @@
-import { useState } from "react";
+import type { FormEvent } from "react";
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import { useAuthStore } from "../stores/auth";
+import { Loader2 } from "lucide-react";
 
 export default function LoginPage() {
-  const login = useAuthStore((s) => s.login);
+  const navigate = useNavigate();
+  const { login, token, isLoading, error, clearError } = useAuthStore((state) => ({
+    login: state.login,
+    token: state.token,
+    isLoading: state.isLoading,
+    error: state.error,
+    clearError: state.clearError,
+  }));
+
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
+  useEffect(() => {
+    if (token) {
+      navigate("/dashboard");
+    }
+  }, [token, navigate]);
+
+  useEffect(() => {
+    return () => clearError();
+  }, [clearError]);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
     await login(email, password);
   }
 
   return (
-    <form onSubmit={handleSubmit}>
-      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
-      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Senha" />
-      <button type="submit">Entrar</button>
-    </form>
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="w-full max-w-md rounded-2xl bg-white p-8 shadow-xl">
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-bold text-gray-900">Bem-vindo de volta</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            Entre com seus dados para gerenciar agendamentos, serviços e barbearias.
+          </p>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700">
+              E-mail
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="seu@email.com"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="mb-1 block text-sm font-medium text-gray-700">
+              Senha
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="••••••••"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isLoading && <Loader2 className="h-4 w-4 animate-spin" />}
+            Entrar
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-gray-600">
+          Ainda não tem uma conta? {" "}
+          <Link to="/register" className="font-semibold text-blue-600 hover:text-blue-700">
+            Cadastre-se agora
+          </Link>
+        </p>
+      </div>
+    </div>
   );
 }

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,0 +1,226 @@
+import type { FormEvent } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import { useAuthStore } from "../stores/auth";
+import { Role } from "../models/user";
+import { Loader2, ShieldCheck, Users, UserRound } from "lucide-react";
+
+const roleOptions = [
+  {
+    role: Role.CLIENT,
+    label: "Cliente",
+    description: "Agende horários e acompanhe seus atendimentos.",
+    icon: Users,
+  },
+  {
+    role: Role.BARBER,
+    label: "Barbeiro",
+    description: "Gerencie sua agenda em uma barbearia cadastrada.",
+    icon: UserRound,
+  },
+  {
+    role: Role.OWNER,
+    label: "Dono de Barbearia",
+    description: "Cadastre sua barbearia e convide sua equipe.",
+    icon: ShieldCheck,
+  },
+] as const;
+
+export default function RegisterPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { register, token, isLoading, error, clearError } = useAuthStore((state) => ({
+    register: state.register,
+    token: state.token,
+    isLoading: state.isLoading,
+    error: state.error,
+    clearError: state.clearError,
+  }));
+
+  const initialRoleFromQuery = useMemo(() => {
+    const roleParam = searchParams.get("role");
+    if (roleParam === Role.BARBER || roleParam === Role.OWNER || roleParam === Role.CLIENT) {
+      return roleParam;
+    }
+    return Role.CLIENT;
+  }, [searchParams]);
+
+  const [selectedRole, setSelectedRole] = useState<Role>(initialRoleFromQuery);
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [barberShopId, setBarberShopId] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (token) {
+      navigate("/dashboard");
+    }
+  }, [token, navigate]);
+
+  useEffect(() => {
+    return () => clearError();
+  }, [clearError]);
+
+  useEffect(() => {
+    setSelectedRole(initialRoleFromQuery);
+  }, [initialRoleFromQuery]);
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    if (password !== confirmPassword) {
+      setFormError("As senhas precisam ser iguais.");
+      return;
+    }
+
+    await register({
+      name,
+      email,
+      password,
+      role: selectedRole,
+      barberShopId: barberShopId ? barberShopId : undefined,
+    });
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-10">
+      <div className="w-full max-w-3xl rounded-2xl bg-white p-8 shadow-xl">
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-gray-900">Crie sua conta no FindCut</h1>
+          <p className="mt-2 text-sm text-gray-600">
+            Escolha o perfil adequado para aproveitar todos os recursos da plataforma.
+          </p>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-3">
+          {roleOptions.map(({ role, label, description, icon: Icon }) => {
+            const isActive = role === selectedRole;
+            return (
+              <button
+                key={role}
+                type="button"
+                onClick={() => setSelectedRole(role)}
+                className={`rounded-xl border p-4 text-left transition-all ${
+                  isActive
+                    ? "border-blue-500 bg-blue-50 shadow-sm"
+                    : "border-gray-200 hover:border-blue-300 hover:bg-blue-50"
+                }`}
+              >
+                <div className={`mb-3 inline-flex rounded-full p-2 ${isActive ? "bg-blue-500 text-white" : "bg-gray-100 text-gray-600"}`}>
+                  <Icon className="h-5 w-5" />
+                </div>
+                <div className="font-semibold text-gray-900">{label}</div>
+                <p className="mt-1 text-xs text-gray-600">{description}</p>
+              </button>
+            );
+          })}
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-8 grid gap-4 sm:grid-cols-2 sm:gap-6">
+          <div className="sm:col-span-1">
+            <label htmlFor="name" className="mb-1 block text-sm font-medium text-gray-700">
+              Nome completo
+            </label>
+            <input
+              id="name"
+              required
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Seu nome"
+            />
+          </div>
+
+          <div className="sm:col-span-1">
+            <label htmlFor="email" className="mb-1 block text-sm font-medium text-gray-700">
+              E-mail
+            </label>
+            <input
+              id="email"
+              type="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="seu@email.com"
+            />
+          </div>
+
+          <div className="sm:col-span-1">
+            <label htmlFor="password" className="mb-1 block text-sm font-medium text-gray-700">
+              Senha
+            </label>
+            <input
+              id="password"
+              type="password"
+              required
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="••••••••"
+            />
+          </div>
+
+          <div className="sm:col-span-1">
+            <label htmlFor="confirm-password" className="mb-1 block text-sm font-medium text-gray-700">
+              Confirmar senha
+            </label>
+            <input
+              id="confirm-password"
+              type="password"
+              required
+              value={confirmPassword}
+              onChange={(event) => setConfirmPassword(event.target.value)}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="••••••••"
+            />
+          </div>
+
+          {selectedRole !== Role.CLIENT && (
+            <div className="sm:col-span-2">
+              <label htmlFor="barbershop-id" className="mb-1 block text-sm font-medium text-gray-700">
+                Código da barbearia (opcional)
+              </label>
+              <input
+                id="barbershop-id"
+                value={barberShopId}
+                onChange={(event) => setBarberShopId(event.target.value)}
+                className="w-full rounded-lg border border-gray-300 px-4 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="Informe o código enviado pelo dono da barbearia"
+              />
+            </div>
+          )}
+
+          {(formError || error) && (
+            <div className="sm:col-span-2">
+              <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+                {formError ?? error}
+              </div>
+            </div>
+          )}
+
+          <div className="sm:col-span-2">
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-blue-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isLoading && <Loader2 className="h-5 w-5 animate-spin" />}
+              Criar conta
+            </button>
+          </div>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-gray-600">
+          Já possui uma conta? {" "}
+          <Link to="/login" className="font-semibold text-blue-600 hover:text-blue-700">
+            Faça login
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,10 +1,12 @@
 import { createBrowserRouter } from "react-router-dom";
 import Home from "../pages/Home";
 import Login from "../pages/Login";
+import Register from "../pages/Register";
 import Dashboard from "../pages/Dashboard";
 
 export const router = createBrowserRouter([
   { path: "/", element: <Home /> },
   { path: "/login", element: <Login /> },
+  { path: "/register", element: <Register /> },
   { path: "/dashboard", element: <Dashboard /> }
 ]);

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,36 +1,74 @@
 import { create } from "zustand";
-import { api } from "../api/client";
-
-interface User {
-  id: string;
-  email: string;
-}
+import { isAxiosError } from "axios";
+import type { User } from "../models/user";
+import {
+  getProfile as getProfileRequest,
+  login as loginRequest,
+  register as registerRequest,
+  type RegisterPayload,
+} from "../api/auth";
 
 interface AuthState {
   user: User | null;
   token: string | null;
+  isLoading: boolean;
+  error: string | null;
   login: (email: string, password: string) => Promise<void>;
+  register: (payload: RegisterPayload) => Promise<void>;
   getProfile: () => Promise<void>;
   logout: () => void;
+  clearError: () => void;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
+const getErrorMessage = (error: unknown) => {
+  if (isAxiosError(error)) {
+    const data = error.response?.data as { message?: string } | undefined;
+    return data?.message ?? "Não foi possível completar a operação.";
+  }
+  return "Algo deu errado. Tente novamente.";
+};
+
+export const useAuthStore = create<AuthState>((set, get) => ({
   user: null,
   token: localStorage.getItem("token"),
+  isLoading: false,
+  error: null,
 
   login: async (email, password) => {
-    const { data } = await api.post("/auth/login", { email, password });
-    localStorage.setItem("token", data.token);
-    set({ user: data.user, token: data.token });
+    set({ isLoading: true, error: null });
+    try {
+      const { token, user } = await loginRequest({ email, password });
+      localStorage.setItem("token", token);
+      set({ user, token, isLoading: false });
+    } catch (error) {
+      localStorage.removeItem("token");
+      set({ error: getErrorMessage(error), isLoading: false, token: null });
+    }
+  },
+
+  register: async (payload) => {
+    set({ isLoading: true, error: null });
+    try {
+      const { token, user } = await registerRequest(payload);
+      localStorage.setItem("token", token);
+      set({ user, token, isLoading: false });
+    } catch (error) {
+      localStorage.removeItem("token");
+      set({ error: getErrorMessage(error), isLoading: false, token: null });
+    }
   },
 
   getProfile: async () => {
+    const token = get().token ?? localStorage.getItem("token");
+    if (!token) return;
+
+    set({ isLoading: true, error: null });
     try {
-      const { data } = await api.get("/users/me");
-      set({ user: data });
-    } catch {
-      set({ user: null, token: null });
+      const data = await getProfileRequest();
+      set({ user: data, token, isLoading: false });
+    } catch (error) {
       localStorage.removeItem("token");
+      set({ user: null, token: null, isLoading: false, error: getErrorMessage(error) });
     }
   },
 
@@ -38,4 +76,6 @@ export const useAuthStore = create<AuthState>((set) => ({
     localStorage.removeItem("token");
     set({ user: null, token: null });
   },
+
+  clearError: () => set({ error: null }),
 }));

--- a/src/stores/barbershop.ts
+++ b/src/stores/barbershop.ts
@@ -1,0 +1,100 @@
+import { create } from "zustand";
+import { isAxiosError } from "axios";
+import type { Barbershop } from "../models/barbershop";
+import type { Invite } from "../models/invite";
+import {
+  createBarberShop,
+  createBarberShopInvite,
+  getBarberShop,
+  listBarberShops,
+  type CreateBarbershopPayload,
+  type CreateInvitePayload,
+} from "../api/barbershops";
+
+interface BarbershopState {
+  barbershops: Barbershop[];
+  currentBarbershop: Barbershop | null;
+  isLoading: boolean;
+  error: string | null;
+  fetchBarbershops: () => Promise<void>;
+  fetchBarbershop: (barbershopId: string) => Promise<Barbershop | null>;
+  addBarbershop: (payload: CreateBarbershopPayload) => Promise<Barbershop | null>;
+  createInvite: (payload: CreateInvitePayload) => Promise<Invite | null>;
+  clearError: () => void;
+}
+
+const getErrorMessage = (error: unknown) => {
+  if (isAxiosError(error)) {
+    const data = error.response?.data as { message?: string } | undefined;
+    return data?.message ?? "Não foi possível carregar os dados.";
+  }
+  return "Algo deu errado. Tente novamente.";
+};
+
+export const useBarbershopStore = create<BarbershopState>((set, get) => ({
+  barbershops: [],
+  currentBarbershop: null,
+  isLoading: false,
+  error: null,
+
+  fetchBarbershops: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const data = await listBarberShops();
+      set({ barbershops: data, isLoading: false });
+    } catch (error) {
+      set({ error: getErrorMessage(error), isLoading: false });
+    }
+  },
+
+  fetchBarbershop: async (barbershopId) => {
+    set({ isLoading: true, error: null });
+    try {
+      const data = await getBarberShop(barbershopId);
+      set({ currentBarbershop: data, isLoading: false });
+      return data;
+    } catch (error) {
+      set({ error: getErrorMessage(error), isLoading: false });
+      return null;
+    }
+  },
+
+  addBarbershop: async (payload) => {
+    set({ isLoading: true, error: null });
+    try {
+      const barbershop = await createBarberShop(payload);
+      set({
+        barbershops: [barbershop, ...get().barbershops],
+        currentBarbershop: barbershop,
+        isLoading: false,
+      });
+      return barbershop;
+    } catch (error) {
+      set({ error: getErrorMessage(error), isLoading: false });
+      return null;
+    }
+  },
+
+  createInvite: async (payload) => {
+    set({ isLoading: true, error: null });
+    try {
+      const invite = await createBarberShopInvite(payload);
+      const barbershops = get().barbershops.map((shop) =>
+        shop.id === payload.barbershopId
+          ? {
+              ...shop,
+              invites: shop.invites ? [invite, ...shop.invites] : [invite],
+            }
+          : shop,
+      );
+
+      set({ barbershops, isLoading: false });
+      return invite;
+    } catch (error) {
+      set({ error: getErrorMessage(error), isLoading: false });
+      return null;
+    }
+  },
+
+  clearError: () => set({ error: null }),
+}));

--- a/src/utils/mock.ts
+++ b/src/utils/mock.ts
@@ -19,8 +19,8 @@ export const mockBarbershops: Barbershop[] = [
         expired: false
       }
     ],
-    createdAt: new Date('2024-01-15'),
-    updatedAt: new Date('2025-01-20'),
+    createdAt: new Date('2024-01-15').toISOString(),
+    updatedAt: new Date('2025-01-20').toISOString(),
     services: [
       { 
         id: '1', 
@@ -28,8 +28,8 @@ export const mockBarbershops: Barbershop[] = [
         name: 'Corte Masculino', 
         price: 35, 
         duration: 30,
-        createdAt: new Date('2024-01-15'),
-        updatedAt: new Date('2024-01-15'),
+        createdAt: new Date('2024-01-15').toISOString(),
+        updatedAt: new Date('2024-01-15').toISOString(),
         bookings: []
       },
       { 
@@ -38,8 +38,8 @@ export const mockBarbershops: Barbershop[] = [
         name: 'Barba', 
         price: 25, 
         duration: 20,
-        createdAt: new Date('2024-01-15'),
-        updatedAt: new Date('2024-01-15'),
+        createdAt: new Date('2024-01-15').toISOString(),
+        updatedAt: new Date('2024-01-15').toISOString(),
         bookings: []
       }
     ]
@@ -53,8 +53,8 @@ export const mockBarbershops: Barbershop[] = [
     phone: '(19) 3345-6789',
     ownerId: 'owner_2',
     invites: [],
-    createdAt: new Date('2024-02-10'),
-    updatedAt: new Date('2025-01-15'),
+    createdAt: new Date('2024-02-10').toISOString(),
+    updatedAt: new Date('2025-01-15').toISOString(),
     services: [
       { 
         id: '3', 
@@ -62,8 +62,8 @@ export const mockBarbershops: Barbershop[] = [
         name: 'Corte + Barba', 
         price: 55, 
         duration: 45,
-        createdAt: new Date('2024-02-10'),
-        updatedAt: new Date('2024-02-10'),
+        createdAt: new Date('2024-02-10').toISOString(),
+        updatedAt: new Date('2024-02-10').toISOString(),
         bookings: []
       },
       { 
@@ -72,8 +72,8 @@ export const mockBarbershops: Barbershop[] = [
         name: 'Corte Social', 
         price: 40, 
         duration: 35,
-        createdAt: new Date('2024-02-10'),
-        updatedAt: new Date('2024-02-10'),
+        createdAt: new Date('2024-02-10').toISOString(),
+        updatedAt: new Date('2024-02-10').toISOString(),
         bookings: []
       }
     ]
@@ -96,8 +96,8 @@ export const mockBarbershops: Barbershop[] = [
         expired: false
       }
     ],
-    createdAt: new Date('2024-03-05'),
-    updatedAt: new Date('2025-01-25'),
+    createdAt: new Date('2024-03-05').toISOString(),
+    updatedAt: new Date('2025-01-25').toISOString(),
     services: [
       { 
         id: '5', 
@@ -105,8 +105,8 @@ export const mockBarbershops: Barbershop[] = [
         name: 'Corte Premium', 
         price: 65, 
         duration: 40,
-        createdAt: new Date('2024-03-05'),
-        updatedAt: new Date('2024-03-05'),
+        createdAt: new Date('2024-03-05').toISOString(),
+        updatedAt: new Date('2024-03-05').toISOString(),
         bookings: []
       },
       { 
@@ -115,8 +115,8 @@ export const mockBarbershops: Barbershop[] = [
         name: 'Tratamento Capilar', 
         price: 80, 
         duration: 60,
-        createdAt: new Date('2024-03-05'),
-        updatedAt: new Date('2024-03-05'),
+        createdAt: new Date('2024-03-05').toISOString(),
+        updatedAt: new Date('2024-03-05').toISOString(),
         bookings: []
       }
     ]


### PR DESCRIPTION
## Summary
- replace mock data usage with API-driven stores and modules
- build registration flow and update authentication handling against the backend
- refresh the home page UI with login/register entry points and live barbershop listings

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dda9a15b3083289e0d949cbc90fd45